### PR TITLE
Update ncorr.m

### DIFF
--- a/ncorr.m
+++ b/ncorr.m
@@ -661,11 +661,26 @@ classdef ncorr < handle
                                     try               
                                         % Do reference image first
                                         [ref_prelim,outstate_ref] = ncorr_util_loadsavedimg(struct_load.reference_save);
-                                        
+                                         % In the case load is not
+                                        % succesful, the following 'if'
+                                        % condition search for the images
+                                        % in the location loaded .mat file
+                                        if (outstate_ref ~= out.success)
+                                            struct_load.reference_save.path=pathname;
+                                            [ref_prelim,outstate_ref] = ncorr_util_loadsavedimg(struct_load.reference_save);
+                                        end
                                         % Do current images next
                                         cur_prelim = ncorr_class_img.empty;
                                         for i = 0:length(struct_load.current_save)-1
                                             [cur_buffer,outstate_cur] = ncorr_util_loadsavedimg(struct_load.current_save(i+1));
+                                            % In the case load is not
+                                            % succesful, the following if
+                                            % condition search for the images
+                                            % in the location loaded .mat file
+                                            if (outstate_cur ~= out.success)
+                                                struct_load.current_save(i+1).path=pathname;
+                                                [cur_buffer,outstate_cur] = ncorr_util_loadsavedimg(struct_load.current_save(i+1));
+                                            end  
                                             if (outstate_cur == out.success)
                                                 cur_prelim(i+1) = cur_buffer;
                                             else


### PR DESCRIPTION
Dear Mr. Blaber,

It has been a long time since I used your code, and I found out that if I move the files to another folder, the Ncorr cannot find out the location of images and gives an error. I made a change in the code. It will also try to load the reference and current photos from the path, where the l load of the *.mat file was requested.

Kind regards,
Mahdi